### PR TITLE
Change Exodus address and Class C marker

### DIFF
--- a/src/omnicore/encoding.cpp
+++ b/src/omnicore/encoding.cpp
@@ -84,7 +84,7 @@ bool OmniCore_Encode_ClassC(const std::vector<unsigned char>& vchPayload,
         std::vector<std::pair <CScript, int64_t> >& vecOutputs)
 {
     std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchOmBytes = GetOmMarker();
+    std::vector<unsigned char> vchOmBytes = GetGcoinMarker();
     vchData.insert(vchData.end(), vchOmBytes.begin(), vchOmBytes.end());
     vchData.insert(vchData.end(), vchPayload.begin(), vchPayload.end());
     if (vchData.size() > nMaxDatacarrierBytes) { return false; }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -3756,7 +3756,7 @@ const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock)
 /**
  * @return The marker for class C transactions.
  */
-const std::vector<unsigned char> GetOmMarker()
+const std::vector<unsigned char> GetGcoinMarker()
 {
     static unsigned char pch[] = {0x67, 0x63, 0x6f, 0x69, 0x6e}; // Hex-encoded: "gcoin"
     return std::vector<unsigned char>(pch, pch + sizeof(pch) / sizeof(pch[0]));

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -587,7 +587,7 @@ int mastercore::GetEncodingClass(const CTransaction& tx, int nBlock)
                 continue;
             }
             if (!scriptPushes.empty()) {
-                std::vector<unsigned char> vchMarker = GetOmMarker();
+                std::vector<unsigned char> vchMarker = GetGcoinMarker();
                 std::vector<unsigned char> vchPushed = ParseHex(scriptPushes[0]);
                 if (vchPushed.size() < vchMarker.size()) {
                     continue;
@@ -1042,7 +1042,7 @@ static int parseTransaction(bool bRPConly, const CTransaction& wtx, int nBlock, 
                     }
                     // TODO: maybe encapsulate the following sort of messy code
                     if (!vstrPushes.empty()) {
-                        std::vector<unsigned char> vchMarker = GetOmMarker();
+                        std::vector<unsigned char> vchMarker = GetGcoinMarker();
                         std::vector<unsigned char> vchPushed = ParseHex(vstrPushes[0]);
                         if (vchPushed.size() < vchMarker.size()) {
                             continue;
@@ -2295,7 +2295,7 @@ bool mastercore_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx,
  */
 bool mastercore::UseEncodingClassC(size_t nDataSize)
 {
-    size_t nTotalSize = nDataSize + GetOmMarker().size(); // Marker "omni"
+    size_t nTotalSize = nDataSize + GetGcoinMarker().size(); // Marker "omni"
     bool fDataEnabled = GetBoolArg("-datacarrier", true);
     int nBlockNow = GetHeight();
     if (!IsAllowedOutputType(TX_NULL_DATA, nBlockNow)) {

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -102,8 +102,8 @@ CCriticalSection cs_tally;
 static string exodus_address = "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P";
 
 static const string exodus_mainnet = "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P";
-static const string exodus_testnet = "mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv";
-static const string getmoney_testnet = "moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP";
+static const string exodus_testnet = "19qMj8EMZ6PLfMqnFjqk1idCA9P3dNits3";
+static const string getmoney_testnet = "19qMj8EMZ6PLfMqnFjqk1idCA9P3dNits3";
 
 static int nWaterlineBlock = 0;
 
@@ -3758,7 +3758,6 @@ const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock)
  */
 const std::vector<unsigned char> GetOmMarker()
 {
-    static unsigned char pch[] = {0x6f, 0x6d, 0x6e, 0x69}; // Hex-encoded: "omni"
-
+    static unsigned char pch[] = {0x67, 0x63, 0x6f, 0x69, 0x6e}; // Hex-encoded: "gcoin"
     return std::vector<unsigned char>(pch, pch + sizeof(pch) / sizeof(pch[0]));
 }

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -144,7 +144,7 @@ const CBitcoinAddress ExodusAddress();
 const CBitcoinAddress ExodusCrowdsaleAddress(int nBlock = 0);
 
 /** Returns the marker for class C transactions. */
-const std::vector<unsigned char> GetOmMarker();
+const std::vector<unsigned char> GetGcoinMarker();
 
 //! Used to indicate, whether to automatically commit created transactions
 extern bool autoCommit;

--- a/src/omnicore/test/parsing_c_tests.cpp
+++ b/src/omnicore/test/parsing_c_tests.cpp
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(trimmed_op_return)
         std::vector<CTxOut> txOutputs;
 
         std::vector<unsigned char> vchFiller(MAX_PACKETS * PACKET_SIZE, 0x07);
-        std::vector<unsigned char> vchPayload = GetOmMarker();
+        std::vector<unsigned char> vchPayload = GetGcoinMarker();
         vchPayload.insert(vchPayload.end(), vchFiller.begin(), vchFiller.end());
 
         // These will be trimmed:


### PR DESCRIPTION
Change testnet Exodus address to 19qMj8EMZ6PLfMqnFjqk1idCA9P3dNits3
Change Class C transaction's marker to "gcoin"
Rename GetOmMaker() to GetGcoinMaker()
